### PR TITLE
feat: load env privkey in config

### DIFF
--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -48,3 +48,4 @@ serde_json = "1.0"
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.18"
+async-trait = "0.1.80"

--- a/crates/builder/src/config.rs
+++ b/crates/builder/src/config.rs
@@ -23,8 +23,8 @@ pub enum ConfigError {
 }
 
 /// Load the private key from environment variables.
-pub fn load_privkey() -> Result<String, ConfigError> {
-    env::var("ZENITH_SEQUENCER_PRIVKEY").map_err(Into::into)
+pub fn load_privkey(key: &str) -> Result<String, ConfigError> {
+    env::var(key).map_err(Into::into)
 }
 
 /// Load the wallet from environment variables.
@@ -32,8 +32,8 @@ pub fn load_privkey() -> Result<String, ConfigError> {
 /// # Panics
 ///
 /// Panics if the env var contents is not a valid secp256k1 private key.
-pub fn load_wallet() -> Result<LocalWallet, ConfigError> {
-    let key = load_privkey()?;
+pub fn load_wallet(key: &str) -> Result<LocalWallet, ConfigError> {
+    let key = load_privkey(key)?;
     let bytes = hex::decode(key.strip_prefix("0x").unwrap_or(&key))?;
     Ok(LocalWallet::from_slice(&bytes).unwrap())
 }

--- a/crates/builder/src/tasks/submit.rs
+++ b/crates/builder/src/tasks/submit.rs
@@ -187,6 +187,8 @@ where
     async fn handle_inbound(&self, in_progress: &InProgressBlock) -> eyre::Result<()> {
         let sig_request = self.construct_sig_request(in_progress).await?;
 
+        // If configured with a local signer, we use it. Otherwise, we ask
+        // quincey (politely)
         let signature = if let Some(signer) = &self.config.local_sequencer_signer {
             signer.sign_hash(&sig_request.signing_hash()).await?
         } else {


### PR DESCRIPTION
Add convenience function for loading privkey from env

TODO:
- load a sequencer credential at runtime
- add credential to config 
- maybe: add `enum LocalOrAwsSigner` to abstract over choices