### PR TITLE
feat(`builder`): Load quincey and RPC url from env vars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "5
 aws-config = "1.1.7"
 aws-sdk-kms = "1.15.0"
 
-hex = "0.4.3"
+hex = { package = "const-hex", version = "1.10", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.197", features = ["derive"] }
 tracing = "0.1.40"
 

--- a/crates/builder/src/env.rs
+++ b/crates/builder/src/env.rs
@@ -4,7 +4,7 @@ use alloy_signer::Signature;
 use alloy_signer_aws::{AwsSigner, AwsSignerError};
 use alloy_signer_wallet::LocalWallet;
 use aws_config::BehaviorVersion;
-use std::{borrow::Cow, env, num};
+use std::{borrow::Cow, env, num, str::FromStr};
 
 /// Abstraction over local signer or
 #[derive(Debug, Clone)]
@@ -106,12 +106,18 @@ pub fn load_privkey(key: &str) -> Result<String, ConfigError> {
 
 /// Load the RPC URL from environment variables.
 pub fn load_rpc() -> Result<Cow<'static, str>, ConfigError> {
-    load_privkey("RPC_URL").map(Into::into)
+    env::var("RPC_URL").map_err(Into::into).map(Into::into)
 }
 
 /// Load our man's Quincey URL from environment variables.
 pub fn load_quincey() -> Result<Cow<'static, str>, ConfigError> {
-    load_privkey("QUINCEY_URL").map(Into::into)
+    env::var("QUINCEY_URL").map_err(Into::into).map(Into::into)
+}
+
+/// Load the ZENITH_ADDRESS from environment variables.
+pub fn load_zenith_address() -> Result<Address, ConfigError> {
+    let address = env::var("ZENITH_ADDRESS")?;
+    Address::from_str(&address).map_err(Into::into)
 }
 
 /// Load the wallet from environment variables.

--- a/crates/builder/src/env.rs
+++ b/crates/builder/src/env.rs
@@ -4,7 +4,7 @@ use alloy_signer::Signature;
 use alloy_signer_aws::{AwsSigner, AwsSignerError};
 use alloy_signer_wallet::LocalWallet;
 use aws_config::BehaviorVersion;
-use std::{env, num};
+use std::{borrow::Cow, env, num};
 
 /// Abstraction over local signer or
 #[derive(Debug, Clone)]
@@ -102,6 +102,16 @@ pub enum ConfigError {
 /// Load the private key from environment variables.
 pub fn load_privkey(key: &str) -> Result<String, ConfigError> {
     env::var(key).map_err(Into::into)
+}
+
+/// Load the RPC URL from environment variables.
+pub fn load_rpc() -> Result<Cow<'static, str>, ConfigError> {
+    load_privkey("RPC_URL").map(Into::into)
+}
+
+/// Load our man's Quincey URL from environment variables.
+pub fn load_quincey() -> Result<Cow<'static, str>, ConfigError> {
+    load_privkey("QUINCEY_URL").map(Into::into)
 }
 
 /// Load the wallet from environment variables.

--- a/crates/builder/src/main.rs
+++ b/crates/builder/src/main.rs
@@ -8,14 +8,13 @@ mod tasks;
 
 use alloy_network::EthereumSigner;
 use alloy_network::TxSigner;
-use alloy_primitives::{address, Address};
+use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use std::borrow::Cow;
 use tokio::select;
 use zenith_types::Zenith;
 
-use crate::env::load_quincey;
-use crate::env::load_rpc;
+use crate::env::{load_quincey, load_rpc, load_zenith_address};
 use crate::service::serve_builder_with_span;
 
 /// Configuration for a builder running a specific rollup on a specific host
@@ -48,12 +47,13 @@ impl ChainConfig {
         local_sequencer_signer: Option<LocalOrAws>,
         rpc_url: Cow<'static, str>,
         quincey_url: Cow<'static, str>,
+        zenith: Address,
     ) -> Self {
         ChainConfig {
             host_chain_id: 17000,
             ru_chain_id: 17001,
             confirmation_buffer: 60 * 20,
-            zenith: address!("97C0E40c6B5bb5d4fa3e2AA1C6b8bC7EA5ECAe31"),
+            zenith,
             quincey_url,
             rpc_url,
             local_sequencer_signer,
@@ -69,7 +69,7 @@ async fn main() -> eyre::Result<()> {
     let span = tracing::info_span!("zenith-builder");
 
     // finish app config by loading key from env
-    let config = ChainConfig::holesky(None, load_rpc()?, load_quincey()?);
+    let config = ChainConfig::holesky(None, load_rpc()?, load_quincey()?, load_zenith_address()?);
 
     // Load builder key from env
     let wallet = LocalOrAws::load("BUILDER_KEY_ID", Some(config.host_chain_id)).await?;

--- a/crates/builder/src/main.rs
+++ b/crates/builder/src/main.rs
@@ -14,6 +14,8 @@ use std::borrow::Cow;
 use tokio::select;
 use zenith_types::Zenith;
 
+use crate::env::load_quincey;
+use crate::env::load_rpc;
 use crate::service::serve_builder_with_span;
 
 /// Configuration for a builder running a specific rollup on a specific host
@@ -40,16 +42,25 @@ pub struct ChainConfig {
     pub use_calldata: bool,
 }
 
-const HOLESKY: ChainConfig = ChainConfig {
-    host_chain_id: 17000,
-    ru_chain_id: 17001,
-    confirmation_buffer: 60 * 20,
-    zenith: address!("97C0E40c6B5bb5d4fa3e2AA1C6b8bC7EA5ECAe31"),
-    quincey_url: Cow::Borrowed("http://quincey.swanny.wtf:8080/signBlock"),
-    rpc_url: Cow::Borrowed("https://ethereum-holesky-rpc.publicnode.com"),
-    local_sequencer_signer: None,
-    use_calldata: true,
-};
+impl ChainConfig {
+    /// Creates a new ChainConfig for the Holesky testnet.
+    const fn holesky(
+        local_sequencer_signer: Option<LocalOrAws>,
+        rpc_url: Cow<'static, str>,
+        quincey_url: Cow<'static, str>,
+    ) -> Self {
+        ChainConfig {
+            host_chain_id: 17000,
+            ru_chain_id: 17001,
+            confirmation_buffer: 60 * 20,
+            zenith: address!("97C0E40c6B5bb5d4fa3e2AA1C6b8bC7EA5ECAe31"),
+            quincey_url,
+            rpc_url,
+            local_sequencer_signer,
+            use_calldata: true,
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -58,10 +69,7 @@ async fn main() -> eyre::Result<()> {
     let span = tracing::info_span!("zenith-builder");
 
     // finish app config by loading key from env
-    let config = ChainConfig {
-        local_sequencer_signer: LocalOrAws::load("SEQUENCER_KEY", None).await.ok(),
-        ..HOLESKY
-    };
+    let config = ChainConfig::holesky(None, load_rpc()?, load_quincey()?);
 
     // Load builder key from env
     let wallet = LocalOrAws::load("BUILDER_KEY_ID", Some(config.host_chain_id)).await?;


### PR DESCRIPTION
Additionally, this PR also changes the const declaration of the holesky testnet, to a const fn on ChainConfig that can load up a holesky config provided an optional signer, rpc url and quincey url.

Closes #7 