### PR TITLE
chore: bump alloy version to  to match reth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,20 +16,20 @@ alloy-primitives = { version = "0.7", features = ["serde", "tiny-keccak"] }
 alloy-sol-types = { version = "0.7", features = ["json"] }
 alloy-rlp = { version = "0.3.4" }
 
-alloy-contract = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b", features = ["k256", "kzg"] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b"}
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b", features = ["ws"] }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-signer-aws = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "64feb9b" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117", features = ["k256", "kzg"] }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117"}
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117", features = ["ws"] }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-signer-aws = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "bd39117" }
 
 aws-config = "1.1.7"
 aws-sdk-kms = "1.15.0"


### PR DESCRIPTION
This PR bumps the version of `alloy` to align with Reth's version for use in Vega.