### PR TITLE
feat(`types`): expose HostOrders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [ "crates/*" ]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.76"
 authors = ["Zenith Contributors"]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod bindings;
-pub use bindings::{Passage, RollupOrders, RollupPassage, Transactor, Zenith};
+pub use bindings::{HostOrders, Passage, RollupOrders, RollupPassage, Transactor, Zenith};
 
 mod block;
 pub use block::{decode_txns, encode_txns, Alloy2718Coder, Coder, ZenithBlock, ZenithTransaction};


### PR DESCRIPTION
also bumps to 0.5.1.