### PR TITLE
adds a minimal makefile for rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: build
+build:
+	@cargo b --release
+
+.PHONY: clean
+clean:
+	@cargo clean
+
+.PHONY: check
+check:
+	@cargo check
+
+.PHONY: test
+test:
+	@cargo test
+
+.PHONY: fmt
+fmt:
+	@cargo fmt --all
+
+.PHONY: clippy
+clippy:
+	@cargo clippy --all-targets --all-features --workspace -- -D warnings


### PR DESCRIPTION
# adds a minimal makefile for rust

This PR adds a Makefile to standardize typical Rust project tasks for linting, testing, and building artifacts from this repo.