### PR TITLE
fix(builder): only reset sleep future when it has elapsed

### DIFF
--- a/crates/builder/src/tasks/block.rs
+++ b/crates/builder/src/tasks/block.rs
@@ -101,10 +101,11 @@ impl BlockBuilder {
 
         let (sender, mut inbound) = mpsc::unbounded_channel();
 
+        let sleep = tokio::time::sleep(Duration::from_secs(self.incoming_transactions_buffer));
+
         let handle = tokio::spawn(
             async move {
                 loop {
-                    let sleep: tokio::time::Sleep = tokio::time::sleep(Duration::from_secs(self.incoming_transactions_buffer));
                     tokio::pin!(sleep);
 
                     select! {
@@ -118,6 +119,8 @@ impl BlockBuilder {
                                     break
                                 }
                             }
+
+                            sleep = tokio::time::sleep(Duration::from_secs(self.incoming_transactions_buffer));
                         }
                         item_res = inbound.recv() => {
                             match item_res {

--- a/crates/builder/src/tasks/block.rs
+++ b/crates/builder/src/tasks/block.rs
@@ -101,7 +101,8 @@ impl BlockBuilder {
 
         let (sender, mut inbound) = mpsc::unbounded_channel();
 
-        let mut sleep = Box::pin(tokio::time::sleep(Duration::from_secs(self.incoming_transactions_buffer)));
+        let mut sleep =
+            Box::pin(tokio::time::sleep(Duration::from_secs(self.incoming_transactions_buffer)));
 
         let handle = tokio::spawn(
             async move {
@@ -119,6 +120,8 @@ impl BlockBuilder {
                                 }
                             }
 
+                            // Reset the sleep timer, as we want to do so when (and only when) our sleep future has elapsed,
+                            // irrespective of whether we have any blocks to build.
                             sleep.as_mut().reset(tokio::time::Instant::now() + Duration::from_secs(self.incoming_transactions_buffer));
                         }
                         item_res = inbound.recv() => {


### PR DESCRIPTION
Right now, when spawning the block builder task, we're spawning the sleep future inside the loop. This means that any of the two `select!` branches will re-set the sleep timer. This is particularly bad on the branch that receives txs: It means that if we constantly received txs in between the incoming transactions buffer, the first branch would never trigger, as it requires the sleep future to elapse, therefore never building a block. This would effectively DDoS the builder.

Fixes ENG-609