### PR TITLE
chore(bindings): make bundle_helper consistent with rest, export all members

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -380,6 +380,15 @@ mod rollup_passage {
     }
 }
 
+mod bundle_helper {
+    alloy_sol_types::sol!(
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        #[sol(rpc)]
+        BundleHelper,
+        "abi/BundleHelper.json"
+    );
+}
+
 pub use zenith::Zenith;
 
 /// Contract Bindings for the RollupOrders contract.
@@ -432,15 +441,9 @@ pub mod RollupPassage {
     pub use super::rollup_passage::UsesPermit2::*;
 }
 
-pub mod bundle_helper {
-    //! Bundle Helper contract bindings
-    alloy_sol_types::sol!(
-        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-        #[sol(rpc)]
-        BundleHelper,
-        "abi/BundleHelper.json"
-    );
-
-    pub use super::bundle_helper::BundleHelper::{new, submitCall, FillPermit2};
+/// Contract Bindings for the BundleHelper contract.
+#[allow(non_snake_case)]
+pub mod BundleHelper {
+    pub use super::bundle_helper::BundleHelper::*;
     pub use super::bundle_helper::Zenith::BlockHeader;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 
 mod bindings;
 pub use bindings::{
-    bundle_helper, mintCall, HostOrders, Passage, RollupOrders, RollupPassage, Transactor, Zenith,
+    mintCall, BundleHelper, HostOrders, Passage, RollupOrders, RollupPassage, Transactor, Zenith,
 };
 
 mod block;


### PR DESCRIPTION
Makes the binding impl for `BundleHelper` consistent with the rest of the file and exports all its members for easier access. This way we avoid re-releasing if we need something else from it.

Closes ENG-719
